### PR TITLE
make it possible to reference fields of enum variant in assoc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,131 +1,111 @@
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 
-use syn::{Error, Result, Variant, ItemFn, FnArg, Attribute, spanned::Spanned};
 use proc_macro::TokenStream;
 use quote::quote;
+use syn::{spanned::Spanned, Attribute, Error, FnArg, ItemFn, Result, Variant};
 
 const FUNC_ATTR: &'static str = "func";
 const ASSOC_ATTR: &'static str = "assoc";
 
 #[proc_macro_derive(Assoc, attributes(func, assoc))]
-pub fn derive_assoc(input: TokenStream) -> TokenStream 
-{
+pub fn derive_assoc(input: TokenStream) -> TokenStream {
     impl_macro(&syn::parse(input).expect("Failed to parse macro input"))
         //.map(|t| {println!("{}", quote!(#t)); t})
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }
 
-fn impl_macro(ast: &syn::DeriveInput) -> Result<proc_macro2::TokenStream>
-{
+fn impl_macro(ast: &syn::DeriveInput) -> Result<proc_macro2::TokenStream> {
     let name = &ast.ident;
     let generics = &ast.generics;
     let generic_params = &generics.params;
-    let fns = ast.attrs
+    let fns = ast
+        .attrs
         .iter()
         .filter(|attr| attr.path.is_ident(FUNC_ATTR))
         .map(|attr| DeriveFunc::parse_sig(&attr.tokens))
         .collect::<Result<Vec<DeriveFunc>>>()?;
-    let variants: Vec<&Variant> = if let syn::Data::Enum(data) = &ast.data
-    {
+    let variants: Vec<&Variant> = if let syn::Data::Enum(data) = &ast.data {
         data.variants.iter().collect()
-    }
-    else
-    {
+    } else {
         panic!("#[derive(Assoc)] only applicable to enums")
     };
-    let functions: Vec<proc_macro2::TokenStream> = fns.into_iter()
+    let functions: Vec<proc_macro2::TokenStream> = fns
+        .into_iter()
         .map(|func| build_function(&variants, func))
         .collect::<Result<Vec<proc_macro2::TokenStream>>>()?;
-    Ok(quote!
-    {
+    Ok(quote! {
         impl <#generic_params> #name #generics
         {
             #(#functions)*
         }
-    }.into())
+    }
+    .into())
 }
 
-fn build_function(variants: &[&Variant], func: DeriveFunc) -> Result<proc_macro2::TokenStream>
-{
+fn build_function(variants: &[&Variant], func: DeriveFunc) -> Result<proc_macro2::TokenStream> {
     let vis = &func.vis;
     let sig = &func.sig;
     // has_self determines whether or not this a reverse assoc
-    let has_self = match func.sig.inputs.first()
-    {
+    let has_self = match func.sig.inputs.first() {
         Some(FnArg::Receiver(_)) => true,
-        Some(FnArg::Typed(pat_type)) => 
-        {
+        Some(FnArg::Typed(pat_type)) => {
             let pat = &pat_type.pat;
             quote!(#pat).to_string().trim() == "self"
         }
         None => false,
     };
-    let is_option = if let syn::ReturnType::Type(_, ty) = &func.sig.output
-    {
+    let is_option = if let syn::ReturnType::Type(_, ty) = &func.sig.output {
         let s = quote!(#ty).to_string();
         let trimmed = s.trim();
         trimmed.starts_with("Option") && trimmed.len() > 6 && trimmed[6..].trim().starts_with("<")
-    }
-    else
-    {
+    } else {
         false
     };
-    let mut arms = variants.iter()
+    let mut arms = variants
+        .iter()
         .map(|variant| build_variant_arm(variant, &func.sig.ident, is_option, has_self, &func.def))
         .collect::<Result<Vec<(proc_macro2::TokenStream, Wildcard)>>>()?;
-    if is_option && !arms.iter().any(|(_, wildcard)| matches!(wildcard, Wildcard::True))
-    { 
+    if is_option
+        && !arms
+            .iter()
+            .any(|(_, wildcard)| matches!(wildcard, Wildcard::True))
+    {
         arms.push((quote!(_ => None,), Wildcard::True))
     }
     // make sure wildcards are last
-    if has_self == false
-    {
+    if has_self == false {
         arms.sort_by(|(_, wildcard1), (_, wildcard2)| wildcard1.cmp(wildcard2));
     }
     let arms = arms.into_iter().map(|(toks, _)| toks);
-    let match_on = if has_self
-    {
+    let match_on = if has_self {
         quote!(self)
-    }
-    else if func.sig.inputs.is_empty()
-    {
+    } else if func.sig.inputs.is_empty() {
         return Err(syn::Error::new(func.span, "Missing parameter"));
-    }
-    else
-    {
+    } else {
         let mut result = quote!();
-        for input in &func.sig.inputs
-        {
-            match input
-            {
-                FnArg::Receiver(_) => 
-                {
+        for input in &func.sig.inputs {
+            match input {
+                FnArg::Receiver(_) => {
                     result = quote!(self);
                     break;
-                },
-                FnArg::Typed(pat_type) => 
-                {
+                }
+                FnArg::Typed(pat_type) => {
                     let pat = &pat_type.pat;
-                    result = if result.is_empty()
-                    {
+                    result = if result.is_empty() {
                         quote!(#pat)
-                    }
-                    else
-                    {
+                    } else {
                         quote!(#result, #pat)
                     };
-                },
+                }
             }
         }
-        if func.sig.inputs.len() > 1
-        {
+        if func.sig.inputs.len() > 1 {
             result = quote!((#result));
         }
         result
     };
-    Ok(quote!
-    {
+    Ok(quote! {
         #vis #sig
         {
             match #match_on
@@ -136,93 +116,110 @@ fn build_function(variants: &[&Variant], func: DeriveFunc) -> Result<proc_macro2
     })
 }
 
-fn build_variant_arm(variant: &Variant, func: &syn::Ident, is_option: bool, has_self: bool, def: &Option<proc_macro2::TokenStream>) -> Result<(proc_macro2::TokenStream, Wildcard)>
-{
+fn build_variant_arm(
+    variant: &Variant,
+    func: &syn::Ident,
+    is_option: bool,
+    has_self: bool,
+    def: &Option<proc_macro2::TokenStream>,
+) -> Result<(proc_macro2::TokenStream, Wildcard)> {
     // Partially parse associations
-    let assocs = Association::get_variant_assocs(variant, !has_self)
-        .filter(|result| 
-        {
-            match result
-            {
-                Ok(assoc) => assoc.func == *func,
-                Err(_) => true
-            }
+    let assocs =
+        Association::get_variant_assocs(variant, !has_self).filter(|result| match result {
+            Ok(assoc) => assoc.func == *func,
+            Err(_) => true,
         });
-    if has_self
-    {
+    if has_self {
         build_fwd_assoc(assocs, variant, is_option, func, def)
-    }
-    else
-    {
+    } else {
         build_rev_assoc(assocs, variant, is_option)
     }
 }
 
-fn build_fwd_assoc(assocs: impl Iterator<Item = Result<Association>>, variant: &Variant, is_option: bool, func_ident: &syn::Ident, def: &Option<proc_macro2::TokenStream>) 
-    -> Result<(proc_macro2::TokenStream, Wildcard)>
-{
+fn build_fwd_assoc(
+    assocs: impl Iterator<Item = Result<Association>>,
+    variant: &Variant,
+    is_option: bool,
+    func_ident: &syn::Ident,
+    def: &Option<proc_macro2::TokenStream>,
+) -> Result<(proc_macro2::TokenStream, Wildcard)> {
     let var_ident = &variant.ident;
-    let fields = match &variant.fields
-    {
-        syn::Fields::Named(fields) => 
-        {
-            let named = fields.named.iter().map(|f| 
-            {
-                let ident = &f.ident;
-                quote!(#ident: _)
-            }).collect::<Vec::<proc_macro2::TokenStream>>();
+    let fields = match &variant.fields {
+        syn::Fields::Named(fields) => {
+            let named = fields
+                .named
+                .iter()
+                .map(|f| {
+                    let ident = &f.ident;
+                    let val: &Option<proc_macro2::Ident> = &f.ident.as_ref().map(|s| {
+                        proc_macro2::Ident::new(
+                            &("_".to_string() + &s.to_string()),
+                            f.span().clone(),
+                        )
+                    });
+                    quote!(#ident: #val)
+                })
+                .collect::<Vec<proc_macro2::TokenStream>>();
             quote!({#(#named),*})
-        },
-        syn::Fields::Unnamed(fields) => 
-        {
-            let unnamed = fields.unnamed.iter().map(|_| quote!(_)).collect::<Vec::<proc_macro2::TokenStream>>();
+        }
+        syn::Fields::Unnamed(fields) => {
+            let unnamed = fields
+                .unnamed
+                .iter()
+                .enumerate()
+                .map(|(i, f)| {
+                    let ident = proc_macro2::Ident::new(
+                        &("_".to_string() + &i.to_string()),
+                        f.span().clone(),
+                    );
+                    quote!(#ident)
+                })
+                .collect::<Vec<proc_macro2::TokenStream>>();
             quote!((#(#unnamed),*))
-        },
-        _ => quote!()
+        }
+        _ => quote!(),
     };
     let assocs = assocs
         .map(|assoc| assoc.map(|assoc| assoc.assoc.unwrap_expr()))
         .collect::<Result<Vec<syn::Expr>>>()?;
-    match assocs.len()
-    {
-        0 => if let Some(tokens) = def 
-        {
-            Ok(quote!{ Self::#var_ident #fields => #tokens, })
-        } 
-        else if is_option
-        {
-            Ok(quote!{ Self::#var_ident #fields => None, })
+    match assocs.len() {
+        0 => {
+            if let Some(tokens) = def {
+                Ok(quote! { Self::#var_ident #fields => #tokens, })
+            } else if is_option {
+                Ok(quote! { Self::#var_ident #fields => None, })
+            } else {
+                Err(Error::new_spanned(
+                    variant,
+                    format!("Missing `assoc` attribute for {}", func_ident),
+                ))
+            }
         }
-        else
-        {
-            Err(Error::new_spanned(variant, format!("Missing `assoc` attribute for {}", func_ident)))
-        },
-        1 => 
-        {
+        1 => {
             let val = &assocs[0];
-            if is_option
-            {
-                if quote!(#val).to_string().trim() == "None"
-                {
-                    Ok(quote!{ Self::#var_ident #fields => #val, })
+            if is_option {
+                if quote!(#val).to_string().trim() == "None" {
+                    Ok(quote! { Self::#var_ident #fields => #val, })
+                } else {
+                    Ok(quote! { Self::#var_ident #fields => Some(#val), })
                 }
-                else
-                {
-                    Ok(quote!{ Self::#var_ident #fields => Some(#val), })
-                }
-            }
-            else
-            {
-                Ok(quote!{ Self::#var_ident #fields => #val, })
+            } else {
+                Ok(quote! { Self::#var_ident #fields => #val, })
             }
         }
-        _ => Err(Error::new_spanned(variant, format!("Too many `assoc` attributes for {}", func_ident)))
-    }.map(|toks| (toks, Wildcard::None))
+        _ => Err(Error::new_spanned(
+            variant,
+            format!("Too many `assoc` attributes for {}", func_ident),
+        )),
+    }
+    .map(|toks| (toks, Wildcard::None))
 }
 
-fn build_rev_assoc(assocs: impl Iterator<Item = Result<Association>>, variant: &Variant, is_option: bool) 
-    -> Result<(proc_macro2::TokenStream, Wildcard)>
-{
+fn build_rev_assoc(
+    assocs: impl Iterator<Item = Result<Association>>,
+    variant: &Variant,
+    is_option: bool,
+) -> Result<(proc_macro2::TokenStream, Wildcard)> {
     let var_ident = &variant.ident;
     let assocs = assocs
         .map(|assoc| assoc.map(|assoc| assoc.assoc.unwrap_pat()))
@@ -230,137 +227,143 @@ fn build_rev_assoc(assocs: impl Iterator<Item = Result<Association>>, variant: &
     let mut concrete_pats: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut wildcard_pat: Option<proc_macro2::TokenStream> = None;
     let mut wildcard_status = Wildcard::False;
-    for pat in assocs.iter()
-    {
-        if !matches!(variant.fields, syn::Fields::Unit)
-        {
-            return Err(Error::new_spanned(variant, "Reverse associations not allowed for tuple or struct-like variants"))
+    for pat in assocs.iter() {
+        if !matches!(variant.fields, syn::Fields::Unit) {
+            return Err(Error::new_spanned(
+                variant,
+                "Reverse associations not allowed for tuple or struct-like variants",
+            ));
         }
-        let arm = if is_option
-        {
+        let arm = if is_option {
             quote!(#pat => Some(Self::#var_ident),)
-        }
-        else
-        {
+        } else {
             quote!(#pat => Self::#var_ident,)
         };
-        if matches!(pat, syn::Pat::Wild(_))
-        {
-            if wildcard_pat.is_some()
-            {
-                return Err(syn::Error::new_spanned(pat, "Only 1 wildcard allowed per reverse association"))
+        if matches!(pat, syn::Pat::Wild(_)) {
+            if wildcard_pat.is_some() {
+                return Err(syn::Error::new_spanned(
+                    pat,
+                    "Only 1 wildcard allowed per reverse association",
+                ));
             }
             wildcard_status = Wildcard::True;
             wildcard_pat = Some(arm);
-        }
-        else
-        {
+        } else {
             concrete_pats.push(arm);
         }
     }
-    if let Some(wildcard_pat) = wildcard_pat
-    {
+    if let Some(wildcard_pat) = wildcard_pat {
         concrete_pats.push(wildcard_pat)
     }
     Ok((quote!(#(#concrete_pats) *), wildcard_status))
 }
 
-/// A container for a function parsed within a `func` attribute. Note that the 
-/// span of the `func` atribute is included because the syn nodes were 
+/// A container for a function parsed within a `func` attribute. Note that the
+/// span of the `func` atribute is included because the syn nodes were
 /// manipulated as a string and have lost therr own span information.
-struct DeriveFunc
-{
+struct DeriveFunc {
     vis: syn::Visibility,
     sig: syn::Signature,
     span: proc_macro2::Span,
-    def: Option<proc_macro2::TokenStream>
+    def: Option<proc_macro2::TokenStream>,
 }
 
 /// An association. Contains a function ident as well as the actual tokens of
-/// the VALUE (not the variant) of the association. 
-struct Association
-{
+/// the VALUE (not the variant) of the association.
+struct Association {
     func: syn::Ident,
-    assoc: AssociationType
+    assoc: AssociationType,
 }
 
-/// An expression for a forward association, a pattern for a reverse 
+/// An expression for a forward association, a pattern for a reverse
 /// association.
-enum AssociationType
-{
+enum AssociationType {
     Expr(syn::Expr),
-    Pat(syn::Pat)
+    Pat(syn::Pat),
 }
 
-/// For reverse associations, this enum keeps track of wldcard patterns. For 
+/// For reverse associations, this enum keeps track of wldcard patterns. For
 /// forward associations, the value is always set to "None". This is also used
 /// to sort reverse associations appropriately. If more complex sorting is to
 /// be implemented, updating this enum would be the best way to start.
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
-enum Wildcard
-{
+enum Wildcard {
     False = 0,
     None = 1,
-    True = 2
+    True = 2,
 }
 
-impl DeriveFunc
-{
+impl DeriveFunc {
     /// Parse a function signature from an attribute
-    fn parse_sig(tokens: &proc_macro2::TokenStream) -> Result<Self>
-    {
+    fn parse_sig(tokens: &proc_macro2::TokenStream) -> Result<Self> {
         let mut s = tokens.to_string();
-        if s.len() > 2
-        {
-            s = format!("{}", &s[1..s.len()-1]);
-            let has_default = &s[s.len()-1..s.len()] == "}";
-            
+        if s.len() > 2 {
+            s = format!("{}", &s[1..s.len() - 1]);
+            let has_default = &s[s.len() - 1..s.len()] == "}";
+
             if !has_default {
                 s = format!("{}{{}}", s);
             }
             let fn_item = syn::parse_str::<ItemFn>(&s)?;
-            
-            let def = if has_default
-            {
-                Some(proc_macro2::TokenStream::from(quote::ToTokens::into_token_stream(fn_item.block)))
-            }
-            else
-            {
+
+            let def = if has_default {
+                Some(proc_macro2::TokenStream::from(
+                    quote::ToTokens::into_token_stream(fn_item.block),
+                ))
+            } else {
                 None
             };
-            Ok(DeriveFunc{ vis: fn_item.vis, sig: fn_item.sig,span: tokens.span(), def })
-        }
-        else
-        {
-            Err(syn::Error::new_spanned(tokens, "Missing function signature"))
+            Ok(DeriveFunc {
+                vis: fn_item.vis,
+                sig: fn_item.sig,
+                span: tokens.span(),
+                def,
+            })
+        } else {
+            Err(syn::Error::new_spanned(
+                tokens,
+                "Missing function signature",
+            ))
         }
     }
 }
 
-impl Association
-{
-    fn new(attr: &Attribute, is_reverse: bool) -> Result<Self>
-    {
+impl Association {
+    fn new(attr: &Attribute, is_reverse: bool) -> Result<Self> {
         let s = attr.tokens.to_string();
-        let s = &s[1..s.len()-1];
-        let first_eq = match s.find("=")
-        {
+        let s = &s[1..s.len() - 1];
+        let first_eq = match s.find("=") {
             Some(result) => result,
-            None => return Err(Error::new_spanned(attr, "Invalid `assoc` attribute, missing `=`"))
+            None => {
+                return Err(Error::new_spanned(
+                    attr,
+                    "Invalid `assoc` attribute, missing `=`",
+                ))
+            }
         };
-        Ok(Association
-        {
-            func: match s[..first_eq].trim().parse()
-            {
+        Ok(Association {
+            func: match s[..first_eq].trim().parse() {
                 Ok(fn_name) => syn::parse2::<syn::Ident>(fn_name)?,
-                Err(_) => return Err(Error::new_spanned(attr, "Invalid `assoc` attribute, failed to parse left side"))
+                Err(_) => {
+                    return Err(Error::new_spanned(
+                        attr,
+                        "Invalid `assoc` attribute, failed to parse left side",
+                    ))
+                }
             },
-            assoc: AssociationType::new(s[first_eq+1..].trim().parse::<proc_macro2::TokenStream>()?, is_reverse)?
+            assoc: AssociationType::new(
+                s[first_eq + 1..]
+                    .trim()
+                    .parse::<proc_macro2::TokenStream>()?,
+                is_reverse,
+            )?,
         })
     }
 
-    fn get_variant_assocs(variant: &Variant, is_reverse: bool) -> impl Iterator<Item = Result<Self>> + '_
-    {
+    fn get_variant_assocs(
+        variant: &Variant,
+        is_reverse: bool,
+    ) -> impl Iterator<Item = Result<Self>> + '_ {
         variant
             .attrs
             .iter()
@@ -369,29 +372,20 @@ impl Association
     }
 }
 
-impl AssociationType
-{
-    fn new(tokens: proc_macro2::TokenStream, is_reverse: bool) -> Result<Self>
-    {
-        if is_reverse
-        {
+impl AssociationType {
+    fn new(tokens: proc_macro2::TokenStream, is_reverse: bool) -> Result<Self> {
+        if is_reverse {
             syn::parse2::<syn::Pat>(tokens).map(AssociationType::Pat)
-        }
-        else
-        {
+        } else {
             syn::parse2::<syn::Expr>(tokens).map(AssociationType::Expr)
         }
     }
 
     /// Appllicable to forward associations only
-    fn unwrap_expr(self) -> syn::Expr
-    {
-        if let Self::Expr(expr) = self
-        {
+    fn unwrap_expr(self) -> syn::Expr {
+        if let Self::Expr(expr) = self {
             expr
-        }
-        else
-        {
+        } else {
             // This should be unreachable. Seeing this means a forward
             // association was parsed as if it were a reverse association.
             panic!("Attempted to unwrap pattern as expression")
@@ -399,15 +393,11 @@ impl AssociationType
     }
 
     /// Appllicable to reverse associations only
-    fn unwrap_pat(self) -> syn::Pat
-    {
-        if let Self::Pat(pat) = self
-        {
+    fn unwrap_pat(self) -> syn::Pat {
+        if let Self::Pat(pat) = self {
             pat
-        }
-        else
-        {
-            // This should be unreachable. Seeing this means a reverse 
+        } else {
+            // This should be unreachable. Seeing this means a reverse
             // association was parsed as if it were a forward association.
             panic!("Attempted to unwrap expression as pattern")
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,8 +2,7 @@ use enum_assoc::Assoc;
 
 // A bit of mock data
 const WA: &'static str = "wa";
-fn some_str_func(s: &'static str) -> String
-{
+fn some_str_func(s: &'static str) -> String {
     String::from("I was created in a function") + s
 }
 
@@ -11,102 +10,129 @@ fn some_str_func(s: &'static str) -> String
 #[func(const fn foo(&self) -> u8)]
 #[func(pub fn bar(&self) -> &'static str)]
 #[func(pub fn maybe_foo(&self) -> Option<u8>)]
-enum TestEnum
-{
-    #[assoc(foo = 255)] 
-    #[assoc(bar = "wow")] 
+enum TestEnum {
+    #[assoc(foo = 255)]
+    #[assoc(bar = "wow")]
     Variant1,
-    #[assoc(foo = 1 + 7)] 
-    #[assoc(bar = "wee")] 
+    #[assoc(foo = 1 + 7)]
+    #[assoc(bar = "wee")]
     Variant2,
     #[assoc(foo = 0)]
-    #[assoc(bar = WA)] 
-    #[assoc(maybe_foo = 18 + 2)] 
-    Variant3
+    #[assoc(bar = WA)]
+    #[assoc(maybe_foo = 18 + 2)]
+    Variant3,
 }
 
 #[derive(Assoc)]
 #[func(pub fn foo(&self, param: u8) -> Option<u8>)]
 #[func(pub fn bar(&self, param: &'static str) -> String)]
 #[func(pub fn baz<T: std::fmt::Debug>(&self, param: T) -> Option<String>)]
-enum TestEnum2
-{
-    #[assoc(bar = String::new() + param)] 
+enum TestEnum2 {
+    #[assoc(bar = String::new() + param)]
     Variant1,
-    #[assoc(foo = 12 + param)] 
-    #[assoc(bar = String::from("Hello") + param)] 
+    #[assoc(foo = 12 + param)]
+    #[assoc(bar = String::from("Hello") + param)]
     Variant2,
-    #[assoc(bar = some_str_func("!"))] 
-    #[assoc(baz = format!("{:?}", param))] 
-    Variant3
+    #[assoc(bar = some_str_func("!"))]
+    #[assoc(baz = format!("{:?}", param))]
+    Variant3,
+}
+
+#[derive(Assoc)]
+#[func(pub const fn bar(&self) -> &'static str)]
+enum TestEnum3 {
+    #[assoc(bar = "1")]
+    Variant1,
+    #[assoc(bar = _0.bar())]
+    Variant2(InnerTestEnum1),
+}
+
+#[derive(Assoc)]
+#[func(pub const fn bar(&self) -> &'static str)]
+enum InnerTestEnum1 {
+    #[assoc(bar = "1")]
+    Variant1,
+    #[assoc(bar = "2")]
+    Variant2,
+    #[assoc(bar = _inner.bar())]
+    Variant3 { inner: InnerTestEnum2 },
+}
+
+#[derive(Assoc)]
+#[func(pub const fn bar(&self) -> &'static str)]
+enum InnerTestEnum2 {
+    #[assoc(bar = "1")]
+    Variant1,
+    #[assoc(bar = "2")]
+    Variant2,
 }
 
 // Including a module to test visibility identifiers
-mod some_mod
-{
+mod some_mod {
     use enum_assoc::Assoc;
 
     #[derive(Assoc, Debug, PartialEq, Eq)]
     #[func(pub fn foo(s: &str) -> Option<Self>)]
     #[func(pub(crate) const fn bar(u: u8) -> Self)]
     #[func(pub fn baz(u1: u8, u2: u8) -> Self)]
-    pub enum TestEnum3
-    {
-        #[assoc(foo = "variant1")] 
-        #[assoc(bar = _)] 
+    pub enum TestEnum3 {
+        #[assoc(foo = "variant1")]
+        #[assoc(bar = _)]
         Variant1,
-        #[assoc(bar = 2)] 
-        #[assoc(foo = "variant2")] 
-        #[assoc(baz = (3, 7))] 
+        #[assoc(bar = 2)]
+        #[assoc(foo = "variant2")]
+        #[assoc(baz = (3, 7))]
         Variant2,
-        #[assoc(foo = "I'm variant 3!")] 
-        #[assoc(foo = "variant3")] 
-        #[assoc(baz = _)] 
-        Variant3
+        #[assoc(foo = "I'm variant 3!")]
+        #[assoc(foo = "variant3")]
+        #[assoc(baz = _)]
+        Variant3,
     }
 }
 
 #[derive(Assoc)]
 #[func(pub fn foo(&'a self) -> Option<()>)]
-pub enum TestEnum4<'a> 
-{
-    #[assoc(foo = ())] 
-    Variant1 { some_str: &'a str },
-    Variant2
+pub enum TestEnum4<'a> {
+    #[assoc(foo = ())]
+    Variant1 {
+        some_str: &'a str,
+    },
+    Variant2,
 }
 
 #[derive(Assoc)]
 #[func(pub fn foo(&'a self) -> Option<()>)]
-pub enum TestEnum5<'a, 'b> 
-{
-    #[assoc(foo = ())] 
-    Variant1 { some_str: &'a str, some_str_2: &'b str },
-    Variant2
+pub enum TestEnum5<'a, 'b> {
+    #[assoc(foo = ())]
+    Variant1 {
+        some_str: &'a str,
+        some_str_2: &'b str,
+    },
+    Variant2,
 }
 
 #[derive(Assoc)]
 #[func(pub fn foo(&self, t: T) -> Option<u8>)]
-pub enum TestEnum6<'a, T> 
-{
-    #[assoc(foo = 1)] 
-    Variant1 { some_str: &'a str },
+pub enum TestEnum6<'a, T> {
+    #[assoc(foo = 1)]
+    Variant1 {
+        some_str: &'a str,
+    },
     Variant2,
-    #[assoc(foo = 3)] 
-    Variant3(T)
+    #[assoc(foo = 3)]
+    Variant3(T),
 }
 
 #[derive(Assoc)]
 #[func(pub fn foo(&self) -> u8 { 0 } )]
-pub enum TestEnumWithDefault
-{
+pub enum TestEnumWithDefault {
     #[assoc(foo = 1)]
     ValueSet,
     UsingDefault,
 }
 
 #[test]
-fn test_fwd()
-{
+fn test_fwd() {
     assert_eq!(TestEnum::Variant1.foo(), 255);
     assert_eq!(TestEnum::Variant2.foo(), 8);
     assert_eq!(TestEnum::Variant3.foo(), 0);
@@ -122,11 +148,18 @@ fn test_fwd()
     assert_eq!(TestEnum2::Variant2.bar(" World!"), "Hello World!");
     assert_eq!(TestEnum2::Variant3.bar("!"), "I was created in a function!");
     assert_eq!(TestEnum2::Variant3.baz(1), Some("1".to_string()));
+    assert_eq!(TestEnum3::Variant2(InnerTestEnum1::Variant2).bar(), "2");
+    assert_eq!(
+        TestEnum3::Variant2(InnerTestEnum1::Variant3 {
+            inner: InnerTestEnum2::Variant1
+        })
+        .bar(),
+        "1"
+    );
 }
 
 #[test]
-fn test_rev()
-{
+fn test_rev() {
     use some_mod::TestEnum3;
     assert_eq!(TestEnum3::foo("variant1"), Some(TestEnum3::Variant1));
     assert_eq!(TestEnum3::foo("variant3"), Some(TestEnum3::Variant3));
@@ -139,18 +172,16 @@ fn test_rev()
 }
 
 #[test]
-fn test_generics()
-{
-    assert_eq!(TestEnum4::Variant1{some_str: "wow"}.foo(), Some(()));
+fn test_generics() {
+    assert_eq!(TestEnum4::Variant1 { some_str: "wow" }.foo(), Some(()));
     assert_eq!(TestEnum4::Variant2.foo(), None);
-    assert_eq!(TestEnum6::Variant1{some_str: "wow"}.foo(3), Some(1));
+    assert_eq!(TestEnum6::Variant1 { some_str: "wow" }.foo(3), Some(1));
     assert_eq!(TestEnum6::Variant2.foo("this could be anything"), None);
     assert_eq!(TestEnum6::Variant3("macaroni").foo("cheese"), Some(3));
 }
 
 #[test]
-fn test_default()
-{
+fn test_default() {
     assert_eq!(TestEnumWithDefault::ValueSet.foo(), 1);
     assert_eq!(TestEnumWithDefault::UsingDefault.foo(), 0);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -148,7 +148,17 @@ fn test_fwd() {
     assert_eq!(TestEnum2::Variant2.bar(" World!"), "Hello World!");
     assert_eq!(TestEnum2::Variant3.bar("!"), "I was created in a function!");
     assert_eq!(TestEnum2::Variant3.baz(1), Some("1".to_string()));
+}
+
+#[test]
+fn test_field_access() {
+    // a variant using no field access:
+    assert_eq!(TestEnum3::Variant1.bar(), "1");
+    // access field of a nested tuple:
+    // `_0.bar()`
     assert_eq!(TestEnum3::Variant2(InnerTestEnum1::Variant2).bar(), "2");
+    // 2-levels deep enum nesting and access a struct field with:
+    // `_inner.bar()`
     assert_eq!(
         TestEnum3::Variant2(InnerTestEnum1::Variant3 {
             inner: InnerTestEnum2::Variant1


### PR DESCRIPTION
It is a simple but powerful feature I needed for my use case:
```rs
#[derive(Error, Debug, Assoc, Clone)]
#[func(pub const fn code(&self) -> &'static str)]
pub enum ServiceError {
    #[error("failed to start or finish a transaction")]
    #[assoc(code = "ELMSC000")]
    TransactionError { source: sea_orm::DbErr },

    //...

    #[error(transparent)]
    #[assoc(code = _source.code())]
    CreateRequestParsingError {
        source: create_language::request_parser::RequestParsingError,
    },
}
```

Using an underscore in bound field values makes the linter happy when the value is unused and I hope this is true for any linter configuration. I found no information which would suggest otherwise.

Unfortunately I hadn't noticed previously that my commits contain some code formatting changes. I hope the PR is still readable enough for a review. 