### PR TITLE
Update to syn2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ documentation = "https://docs.rs/enum-assoc"
 proc-macro = true
 
 [dependencies]
-syn = {version = "1.0", features = ["full"]}
+syn = {version = "2.0", features = ["full"]}
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
 
 use proc_macro::TokenStream;
 use quote::{quote, ToTokens};
-use syn::{spanned::Spanned, Attribute, Error, FnArg, ItemFn, Result, Variant};
+use syn::parse::{Parse, ParseStream};
+use syn::{parenthesized, spanned::Spanned, Error, FnArg, Result, Token, Variant};
 
 const FUNC_ATTR: &'static str = "func";
 const ASSOC_ATTR: &'static str = "assoc";
@@ -23,7 +24,7 @@ fn impl_macro(ast: &syn::DeriveInput) -> Result<proc_macro2::TokenStream> {
         .attrs
         .iter()
         .filter(|attr| attr.path().is_ident(FUNC_ATTR))
-        .map(|attr| DeriveFunc::parse_sig(&attr.to_token_stream()))
+        .map(|attr| syn::parse2::<DeriveFunc>(attr.meta.to_token_stream()))
         .collect::<Result<Vec<DeriveFunc>>>()?;
     let variants: Vec<&Variant> = if let syn::Data::Enum(data) = &ast.data {
         data.variants.iter().collect()
@@ -293,70 +294,54 @@ enum Wildcard {
     True = 2,
 }
 
-impl DeriveFunc {
+impl Parse for DeriveFunc {
     /// Parse a function signature from an attribute
-    fn parse_sig(tokens: &proc_macro2::TokenStream) -> Result<Self> {
-        let mut s = tokens.to_string();
-        if s.len() > 2 {
-            s = format!("{}", &s[7..s.len() - 2]);
-            let has_default = &s[s.len() - 1..s.len()] == "}";
-
-            if !has_default {
-                s = format!("{}{{}}", s);
-            }
-            let fn_item = syn::parse_str::<ItemFn>(&s)?;
-
-            let def = if has_default {
-                Some(proc_macro2::TokenStream::from(
-                    quote::ToTokens::into_token_stream(fn_item.block),
-                ))
+    fn parse(input: ParseStream) -> Result<Self> {
+        input.step(|cursor| {
+            if let Some((_, next)) = cursor.token_tree() {
+                Ok(((), next))
             } else {
-                None
-            };
-            Ok(DeriveFunc {
-                vis: fn_item.vis,
-                sig: fn_item.sig,
-                span: tokens.span(),
-                def,
-            })
+                Err(cursor.error("Missing function signature"))
+            }
+        })?;
+        let content;
+        parenthesized!(content in input);
+        let vis = content.parse::<syn::Visibility>()?;
+        let sig = content.parse::<syn::Signature>()?;
+        let def = if content.is_empty() {
+            None
         } else {
-            Err(syn::Error::new_spanned(
-                tokens,
-                "Missing function signature",
-            ))
-        }
+            let block = content.parse::<syn::Block>()?;
+            Some(proc_macro2::TokenStream::from(ToTokens::into_token_stream(
+                block,
+            )))
+        };
+        Ok(DeriveFunc {
+            vis,
+            sig,
+            span: content.span(),
+            def,
+        })
     }
 }
 
 impl Association {
-    fn new(attr: &Attribute, is_reverse: bool) -> Result<Self> {
-        let s = attr.to_token_stream().to_string();
-        let s = &s[8..s.len() - 2];
-        let first_eq = match s.find("=") {
-            Some(result) => result,
-            None => {
-                return Err(Error::new_spanned(
-                    attr,
-                    "Invalid `assoc` attribute, missing `=`",
-                ))
+    fn new(input: ParseStream, is_reverse: bool) -> Result<Self> {
+        input.step(|cursor| {
+            if let Some((_, next)) = cursor.token_tree() {
+                Ok(((), next))
+            } else {
+                Err(cursor.error("Unexpected empty `assoc` attribute"))
             }
-        };
+        })?;
+
+        let content;
+        parenthesized!(content in input);
+        let func = content.parse::<syn::Ident>()?;
+        content.parse::<Token![=]>()?;
         Ok(Association {
-            func: match s[..first_eq].trim().parse() {
-                Ok(fn_name) => syn::parse2::<syn::Ident>(fn_name)?,
-                Err(_) => {
-                    return Err(Error::new_spanned(
-                        attr,
-                        "Invalid `assoc` attribute, failed to parse left side",
-                    ))
-                }
-            },
-            assoc: AssociationType::new(
-                s[first_eq + 1..]
-                    .trim()
-                    .parse::<proc_macro2::TokenStream>()?,
-                is_reverse,
-            )?,
+            func,
+            assoc: AssociationType::new(&content, is_reverse)?,
         })
     }
 
@@ -368,16 +353,21 @@ impl Association {
             .attrs
             .iter()
             .filter(|assoc_attr| assoc_attr.path().is_ident(ASSOC_ATTR))
-            .map(move |attr| Association::new(attr, is_reverse))
+            .map(move |attr| {
+                syn::parse::Parser::parse2(
+                    |input: ParseStream| Association::new(input, is_reverse),
+                    attr.meta.to_token_stream(),
+                )
+            })
     }
 }
 
 impl AssociationType {
-    fn new(tokens: proc_macro2::TokenStream, is_reverse: bool) -> Result<Self> {
+    fn new(input: ParseStream, is_reverse: bool) -> Result<Self> {
         if is_reverse {
-            syn::parse::Parser::parse2(syn::Pat::parse_single, tokens).map(AssociationType::Pat)
+            syn::Pat::parse_single(input).map(AssociationType::Pat)
         } else {
-            syn::parse2::<syn::Expr>(tokens).map(AssociationType::Expr)
+            syn::Expr::parse(input).map(AssociationType::Expr)
         }
     }
 


### PR DESCRIPTION
The `syn` crate has been updated, and the internal breaking changes have been addressed.

Due to this version bump, the whole attribute is now received by `DeriveFunc` and `Association`, which required updating the string offsets. I took this opportunity to completely remove the `tokens -> string -> tokens` operations. Attributes now always work at token level.